### PR TITLE
Allow support for empty element in array as function arg

### DIFF
--- a/test/limit-destructured-arg-depth.spec.js
+++ b/test/limit-destructured-arg-depth.spec.js
@@ -16,6 +16,7 @@ ruleTester.run('limit-destructured-arg-depth', rule, {
 
         { code: 'function fn() {}' },
         { code: 'function fn([]) {}' },
+        { code: 'function fn([,]) {}' },
         { code: 'function fn([]) {}', options: [{ max: 1 }] },
         { code: 'function fn([[hi]]) {}', options: [{ max: 2 }] },
     ],

--- a/test/limit-num-destructured-arg-properties.spec.js
+++ b/test/limit-num-destructured-arg-properties.spec.js
@@ -14,6 +14,7 @@ ruleTester.run('limit-num-destructured-arg-properties', rule, {
         { code: 'function fn({ prop1, prop2, prop3, prop4 }) {}', options: [{ max: 4 }] },
 
         { code: 'function fn([]) {}' },
+        { code: 'function fn([,]) {}' },
         { code: 'function fn([[]]) {}' },
         { code: 'function fn([[], [], []]) {}' },
         { code: 'function fn([[], [], []]) {}', options: [{ max: 3 }] },

--- a/test/limit-num-destructured-args.spec.js
+++ b/test/limit-num-destructured-args.spec.js
@@ -14,6 +14,7 @@ ruleTester.run('limit-num-destructured-args', rule, {
 
         { code: 'function fn() {}' },
         { code: 'function fn([]) {}' },
+        { code: 'function fn([,]) {}' },
         { code: 'function fn([]) {}', options: [{ max: 1 }] },
         { code: 'function fn([], []) {}', options: [{ max: 2 }] },
     ],

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -12,8 +12,8 @@ function isFunctionType(node) {
 }
 
 function isObjectOrArrayPattern(node) {
-    return  node.type === 'ObjectPattern' ||
-            node.type === 'ArrayPattern';
+    return node && (node.type === 'ObjectPattern' ||
+        node.type === 'ArrayPattern');
 }
 
 function getNodeDepth(node) {


### PR DESCRIPTION
An example code that was throwing the parsing error:
```
list.filter(([, numErrors]) => numErrors > 0);
              ^ this empty element in destructuring would be parsed as a NULL node.
```

Fix is to perform a null check.